### PR TITLE
Removing references to not available objects.

### DIFF
--- a/locale/de_DE.po
+++ b/locale/de_DE.po
@@ -1,0 +1,15 @@
+#
+msgid ""
+msgstr "Content-Type: text/plain; charset=utf-8\n"
+
+msgctxt "field:party.payment_profile,stripe_customer_id:"
+msgid "Stripe Customer ID"
+msgstr "Stripe Kunden-ID"
+
+msgctxt "field:payment_gateway.gateway,stripe_api_key:"
+msgid "Stripe API Key"
+msgstr "Stripe API Schlüssel"
+
+msgctxt "view:payment_gateway.gateway:"
+msgid "Stripe Settings"
+msgstr "Stripe Einstellungen"

--- a/transaction.py
+++ b/transaction.py
@@ -174,7 +174,7 @@ class PaymentTransactionStripe:
                 'exp_month': card_info.expiry_month,
                 'exp_year': card_info.expiry_year,
                 'cvc': card_info.csc,
-                'name': card_info.owner or self.address.name or self.party.name
+                'name': card_info.owner,
             }
             charge_data['source'].update(self.address.get_address_for_stripe())
 
@@ -293,9 +293,7 @@ class AddPaymentProfile:
                 'exp_month': card_info.expiry_month,
                 'exp_year': card_info.expiry_year,
                 'cvc': card_info.csc,
-                'name': (
-                    card_info.owner or self.address.name or self.party.name
-                ),
+                'name': card_info.owner,
             },
         }
         profile_data['source'].update(


### PR DESCRIPTION
Models party or address are not directly available in Model 'party.party.payment_profile.add'. Since the name field in the CreditCard form is required anyway, it should be best to only refer to that field. Downstreams can still override the field to be not required and the request still works with an empty name (string) provided.